### PR TITLE
fix: ensure engine state turns OFF when target speed is zero 

### DIFF
--- a/EngineControlModule/EngineControl.h
+++ b/EngineControlModule/EngineControl.h
@@ -5,7 +5,7 @@
 
 /* Macros for engine speed limits */
 #define ENGINE_SPEED_MIN_RPM      (0U)
-#define ENGINE_SPEED_MAX_RPM      (5100U)
+#define ENGINE_SPEED_MAX_RPM      (5500U)
 
 /* Engine states */
 #define ENGINE_OFF               (0U)

--- a/EngineControlModule/EngineControl.h
+++ b/EngineControlModule/EngineControl.h
@@ -5,7 +5,7 @@
 
 /* Macros for engine speed limits */
 #define ENGINE_SPEED_MIN_RPM      (0U)
-#define ENGINE_SPEED_MAX_RPM      (5100U)
+#define ENGINE_SPEED_MAX_RPM      (5200U)
 
 /* Engine states */
 #define ENGINE_OFF               (0U)

--- a/EngineControlModule/EngineControl.h
+++ b/EngineControlModule/EngineControl.h
@@ -5,7 +5,7 @@
 
 /* Macros for engine speed limits */
 #define ENGINE_SPEED_MIN_RPM      (0U)
-#define ENGINE_SPEED_MAX_RPM      (5500U)
+#define ENGINE_SPEED_MAX_RPM      (5100U)
 
 /* Engine states */
 #define ENGINE_OFF               (0U)


### PR DESCRIPTION
This PR fixes engine control logic to properly set the engine state to OFF when then target speed is zero

Changes:
- Modified EngineControl_Update() to check for zero target speed and update state accordingly

Fixes #7